### PR TITLE
Update mod for Minecraft 26.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # Zombie Conversion
 
-This is a little mod that adds a gamrule to guarantee the infection of a villager regardless of difficulty.
+This is a little mod that adds a gamerule to guarantee the infection of a villager, or no infection at all, regardless of difficulty.

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '1.14-SNAPSHOT'
+	id 'fabric-loom' version '1.15-SNAPSHOT'
 	id 'maven-publish'
 }
 
@@ -21,7 +21,7 @@ repositories {
 dependencies {
 	// To change the versions see the gradle.properties file
 	minecraft "com.mojang:minecraft:${project.minecraft_version}"
-	mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
+	mappings loom.officialMojangMappings()
 	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 
 	// Fabric API. This is technically optional, but you probably want it anyway.

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '1.15-SNAPSHOT'
+	id 'net.fabricmc.fabric-loom' version '1.15-SNAPSHOT'
 	id 'maven-publish'
 }
 
@@ -21,11 +21,11 @@ repositories {
 dependencies {
 	// To change the versions see the gradle.properties file
 	minecraft "com.mojang:minecraft:${project.minecraft_version}"
-	mappings loom.officialMojangMappings()
-	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
+	//mappings loom.officialMojangMappings()
+	implementation "net.fabricmc:fabric-loader:${project.loader_version}"
 
 	// Fabric API. This is technically optional, but you probably want it anyway.
-	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
+	implementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 	
 }
 
@@ -47,8 +47,8 @@ java {
 	// If you remove this line, sources will not be generated.
 	withSourcesJar()
 
-	sourceCompatibility = JavaVersion.VERSION_21
-	targetCompatibility = JavaVersion.VERSION_21
+	sourceCompatibility = JavaVersion.VERSION_25
+	targetCompatibility = JavaVersion.VERSION_25
 }
 
 jar {

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,13 +5,13 @@ org.gradle.parallel=true
 # Fabric Properties
 # check these on https://fabricmc.net/develop
 minecraft_version=1.21.11
-yarn_mappings=1.21.11+build.1
-loader_version=0.18.2
+#yarn_mappings=1.21.11+build.1
+loader_version=0.18.4
 
 # Mod Properties
-mod_version=1.0.1-1.21.11
+mod_version=1.0.1-1.21.11_unobfuscated
 maven_group=me.blackfur.zombieconversion
 archives_base_name=zombieconversion
 
 # Dependencies
-fabric_version=0.139.4+1.21.11
+fabric_version=0.141.3+1.21.11

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,14 +4,14 @@ org.gradle.parallel=true
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=1.21.11
+minecraft_version=26.1
 #yarn_mappings=1.21.11+build.1
 loader_version=0.18.4
 
 # Mod Properties
-mod_version=1.0.1-1.21.11_unobfuscated
+mod_version=1.0.1-26.1
 maven_group=me.blackfur.zombieconversion
 archives_base_name=zombieconversion
 
 # Dependencies
-fabric_version=0.141.3+1.21.11
+fabric_version=0.144.0+26.1

--- a/src/main/java/me/blackfur/zombieconversion/ZombieConversion.java
+++ b/src/main/java/me/blackfur/zombieconversion/ZombieConversion.java
@@ -2,11 +2,11 @@ package me.blackfur.zombieconversion;
 
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.gamerule.v1.GameRuleBuilder;
-import net.minecraft.util.Identifier;
-import net.minecraft.world.rule.GameRule;
+import net.minecraft.resources.Identifier;
+import net.minecraft.world.level.gamerules.GameRule;
 
 public class ZombieConversion implements ModInitializer {
-    public static final GameRule<ConversionSetting> GUARANTEED_CONVERSION = GameRuleBuilder.forEnum(ConversionSetting.VANILLA).buildAndRegister(Identifier.of("zombieconversion", "guaranteed_conversion"));
+    public static final GameRule<ConversionSetting> GUARANTEED_CONVERSION = GameRuleBuilder.forEnum(ConversionSetting.VANILLA).buildAndRegister(Identifier.fromNamespaceAndPath("zombieconversion", "guaranteed_conversion"));
     @Override
     public void onInitialize() {
     }

--- a/src/main/java/me/blackfur/zombieconversion/mixin/ZombieConversionMixin.java
+++ b/src/main/java/me/blackfur/zombieconversion/mixin/ZombieConversionMixin.java
@@ -1,20 +1,20 @@
 package me.blackfur.zombieconversion.mixin;
 
 import me.blackfur.zombieconversion.ConversionSetting;
-import net.minecraft.entity.mob.ZombieEntity;
-import net.minecraft.server.world.ServerWorld;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.Difficulty;
+import net.minecraft.world.entity.monster.zombie.Zombie;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
 import static me.blackfur.zombieconversion.ZombieConversion.GUARANTEED_CONVERSION;
 
-@Mixin(ZombieEntity.class)
+@Mixin(Zombie.class)
 public class ZombieConversionMixin {
-    @Redirect(method = "onKilledOther", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/world/ServerWorld;getDifficulty()Lnet/minecraft/world/Difficulty;"))
-    private Difficulty injected(ServerWorld serverWorld) {
-        var gameRuleSetting = serverWorld.getGameRules().getValue(GUARANTEED_CONVERSION);
+    @Redirect(method = "killedEntity", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/level/ServerLevel;getDifficulty()Lnet/minecraft/world/Difficulty;"))
+    private Difficulty injected(ServerLevel serverWorld) {
+        var gameRuleSetting = serverWorld.getGameRules().get(GUARANTEED_CONVERSION);
         if (gameRuleSetting == ConversionSetting.ALWAYS) {
             return Difficulty.HARD;
         } else if (gameRuleSetting == ConversionSetting.NEVER) {

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -21,8 +21,8 @@
 	],
 	"depends": {
 		"fabricloader": ">=0.18.2",
-		"minecraft": "~1.21.11",
-		"java": ">=21",
+		"minecraft": "~26.1",
+		"java": ">=25",
 		"fabric-api": "*"
 	}
 }


### PR DESCRIPTION
Featuring less obfuscations!!! this means the mappings were changed from yarn to the official Mojang ones.
Also the update needs Java 25 so the mod reflects that too.
Tested on a server with Fabric Loader 0.18.4 and fabric-api 0.144.0+26.1